### PR TITLE
Passage de la licence ODbL vers CC-BY-SA-4.0

### DIFF
--- a/resources/views/data.blade.php
+++ b/resources/views/data.blade.php
@@ -7,8 +7,7 @@
             <h4>Licence</h4>
             <p>
                 Les données d'annotation collective établies dans cette plateforme sont disponibles au téléchargement
-                sous la licence <a href="https://spdx.org/licenses/ODbL-1.0.html#licenseText">ODC Open Database License
-                    (ODbL) version 1.0</a>.
+                sous la licence <a href="https://spdx.org/licenses/CC-BY-SA-4.0.html#licenseText">Creative Commons Attribution Share Alike 4.0 International (CC-BY-SA-4.0)</a>.
             </p>
             <h4>Format</h4>
             <p>


### PR DESCRIPTION
Proposition de changer pour la licence CC-BY-SA qui obligera les réutilisations à rester sous la même licence, chose que l'ODbL ne garantit QUE pour les bases de données et pas pour les réutilisation d'un autre type.
Pour info, les données du Grand Débat publiées par Code For France, sont elles aussi sous cette licence (CC-BY-SA 4.0).